### PR TITLE
Call to new assertMatchesRegularExpression() when available

### DIFF
--- a/tests/filter_test.php
+++ b/tests/filter_test.php
@@ -71,7 +71,12 @@ class filter_moodledocs_testcase extends basic_testcase {
             $msg = "Testing text '$text':";
             $result = $filter->filter($text);
 
-            $this->assertRegExp($expected, $result, $msg);
+            // TODO: Remove once out lower PHPUnit version is 9.5.
+            if (!method_exists($this, 'assertMatchesRegularExpression')) {
+                $this->assertRegExp($expected, $result, $msg); // Pre PHPUnit 9.5.
+            } else {
+                $this->assertMatchesRegularExpression($expected, $result, $msg);
+            }
         }
     }
 }


### PR DESCRIPTION
PHPUnit 9.1 deprecates assertRegExp() and will be removed in PHPUnit 10

Link: https://github.com/sebastianbergmann/phpunit/blob/9.1.0/ChangeLog-9.1.md

This commit conditionally picks the new assertion when available,
falling back to the old, keeping compatibility with older PHPUnit (<9.1)
versions.